### PR TITLE
Feature/universe selection

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -19,4 +19,5 @@ lib_deps =
 	ottowinter/ESPAsyncWebServer-esphome@^3.1.0
 	arduino-libraries/ArduinoMDNS@^0.0.0
 	alanswx/ESPAsyncWiFiManager@^0.31
+	bblanchon/ArduinoJson@5.12.0
 monitor_speed = 115200

--- a/src/artnet_read.cpp
+++ b/src/artnet_read.cpp
@@ -5,17 +5,17 @@
 const bool ARTNET_DMX_DEBUG = true;
 
 ArtnetWifi _artnet;
-int dmx_universe = 1;
+int dmx_port1_artnet_universe = 1;
 
 u_int8_t artnet_dmx_frames[ARTNET_MAX_UNIVERSES][ARTNET_MAX_CHANNELS_PER_UNIVERSE];
 
 // DMX: Univ: 0, Seq: 249, Data (512): 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 ...
-void artnet_dmx_debug(uint16_t universe, uint16_t length, uint8_t sequence, uint8_t *data)
+void artnet_dmx_debug(uint16_t artnet_universe, uint16_t length, uint8_t sequence, uint8_t *data)
 {
   bool tail = false;
 
-  Serial.print("artnet_read debug: universe:");
-  Serial.print(universe, DEC);
+  Serial.print("artnet_read debug: artnet_universe:");
+  Serial.print(artnet_universe, DEC);
   Serial.print(" sequence:");
   Serial.print(sequence, DEC);
   Serial.print(" length:");
@@ -40,15 +40,16 @@ void artnet_dmx_debug(uint16_t universe, uint16_t length, uint8_t sequence, uint
   Serial.println();
 }
 
-void _onDmxFrame(uint16_t universe, uint16_t length, uint8_t sequence, uint8_t *data)
+void _onDmxFrame(uint16_t artnet_universe, uint16_t length, uint8_t sequence, uint8_t *data)
 {
 
-  if (universe > 0 && universe < ARTNET_MAX_UNIVERSES)
+  if (artnet_universe >= 0 && artnet_universe < ARTNET_MAX_UNIVERSES)
   {
-    uint16_t channels = (length < ARTNET_MAX_CHANNELS_PER_UNIVERSE) ? length : ARTNET_MAX_CHANNELS_PER_UNIVERSE;
+    uint16_t channels = (length <= ARTNET_MAX_CHANNELS_PER_UNIVERSE) ? length : ARTNET_MAX_CHANNELS_PER_UNIVERSE;
+
     for (u_int16_t c = 0; c < channels; c++)
     {
-      artnet_dmx_frames[universe-1][c] = data[c];
+      artnet_dmx_frames[artnet_universe][c] = data[c];
     }
   }
   else
@@ -58,13 +59,13 @@ void _onDmxFrame(uint16_t universe, uint16_t length, uint8_t sequence, uint8_t *
   }
 
   if (ARTNET_DMX_DEBUG)
-    artnet_dmx_debug(universe, length, sequence, data);
+    artnet_dmx_debug(artnet_universe, length, sequence, data);
 }
 
 void artnet_setup()
 {
-  dmx_universe = atoi(spiffs_config_get("wifi_manager_universe").c_str());
-  Serial.printf("artnet_read: setting universe to %d\n", dmx_universe);
+  dmx_port1_artnet_universe = atoi(spiffs_config_get("wifi_manager_dmx_port1_artnet_universe").c_str());
+  Serial.printf("artnet_read: setting dmx_port1_artnet_universe to %d\n", dmx_port1_artnet_universe);
   _artnet.setArtDmxCallback(_onDmxFrame);
   _artnet.begin();
 }
@@ -78,10 +79,10 @@ int read_from_artnet(u_int8_t *data)
     data[0] = 0;
 
     uint16_t channels = (ARTNET_MAX_CHANNELS_PER_UNIVERSE < 512) ? ARTNET_MAX_CHANNELS_PER_UNIVERSE : 512;
-  
+
     for (u_int16_t c = 0; c < channels; c++)
     {
-      data[c + 1] = artnet_dmx_frames[dmx_universe-1][c];
+      data[c + 1] = artnet_dmx_frames[dmx_port1_artnet_universe][c];
     }
 
     return 1;

--- a/src/artnet_read.h
+++ b/src/artnet_read.h
@@ -2,7 +2,7 @@
 #include <ArtnetWifi.h>
 
 #define ARTNET_MAX_CHANNELS_PER_UNIVERSE 512
-#define ARTNET_MAX_UNIVERSES 1
+#define ARTNET_MAX_UNIVERSES 18
 
 void artnet_setup();
 int read_from_artnet(u_int8_t*);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,22 +20,26 @@ unsigned long lastUpdate = millis();
 // NOT OUR PROBLEM Configure Router and PC (SSID, Password, Physical Location)
 // DONE Create case (final assembly)
 // DONE MDNS
-// IN PROGRESS Web Interface
+// DONE Web Interface
 // DONE First Time Setup (Interactive WiFi Initialisation)
-// Web universe and channel config
-// Test with actual lights
-// Test during school assemblies (with full audience)
+// DONE Web universe config
+// DONE Test with actual lights
+// DONE Test during school assemblies (with full audience)
+// Web DNS name config
+
+// DONE Install 5V LED
+// Test transmit and receive of second device
+// Complete physical build of second device
+// Create and freeze Release 1 code version
 
 // Web debug console (display log messages)
-// Web DNS name config
-// Install 5V LED
 // Rename DMX files
 // Tidy code
 
 // Web Mode config (RX/TX)
 // Web LED strip control
 
-// second DMX port
+// Second DMX port
 // Document
 
 // TO REVIEW...

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,15 +16,26 @@ unsigned long lastUpdate = millis();
 /* =-=-=-= BACKLOG OF WORK =-=-=-= */
 
 // Sprint Goal: know we are ready to run the show (box created and tested with real lights, ideally with audience)
-// Tidy up code
-// Configure Router and PC (SSID, Password, Physical Location)
-// Create case (final assembly)
+// DONE Tidy up code
+// NOT OUR PROBLEM Configure Router and PC (SSID, Password, Physical Location)
+// DONE Create case (final assembly)
+// DONE MDNS
+// IN PROGRESS Web Interface
+// DONE First Time Setup (Interactive WiFi Initialisation)
+// Web universe and channel config
 // Test with actual lights
+// Test during school assemblies (with full audience)
 
-// MDNS Setup
-//    Remote debug
+// Web debug console (display log messages)
+// Web DNS name config
+// Install 5V LED
+// Rename DMX files
+// Tidy code
 
-// Add second DMX port
+// Web Mode config (RX/TX)
+// Web LED strip control
+
+// second DMX port
 // Document
 
 // TO REVIEW...

--- a/src/spiffs_config.cpp
+++ b/src/spiffs_config.cpp
@@ -3,14 +3,15 @@
 #include <ArduinoJson.h> //https://github.com/bblanchon/ArduinoJson
 #include <WString.h>
 
-void spiffs_config_begin_and_reformat_if_necessary() {
+void spiffs_config_begin_and_reformat_if_necessary()
+{
   SPIFFS.begin(true);
 }
 
-String spiffs_config_get(String name) {
+String spiffs_config_get(String name)
+{
   Serial.println("mounting FS...");
   spiffs_config_begin_and_reformat_if_necessary();
-
 
   Serial.println("mounted file system");
   if (SPIFFS.exists("/config.json"))
@@ -43,16 +44,17 @@ String spiffs_config_get(String name) {
     }
   }
 
-  return (String) NULL; // TODO something better than returning nulls
+  return (String)NULL; // TODO something better than returning nulls
 }
 
-void spiffs_config_set(String name, String value) {
+void spiffs_config_set(String name, String value)
+{
   Serial.println("Saving config");
   spiffs_config_begin_and_reformat_if_necessary();
 
   DynamicJsonBuffer jsonBuffer;
   JsonObject &json = jsonBuffer.createObject();
-  
+
   // TODO this will overwrite all file contents with just one value.  need to support read->modify->write instead
   json[name] = value;
 
@@ -66,6 +68,7 @@ void spiffs_config_set(String name, String value) {
   {
     Serial.print("JSON config file: ");
     json.printTo(Serial);
+    Serial.println();
     json.printTo(configFile);
     configFile.close();
   }

--- a/src/spiffs_config.cpp
+++ b/src/spiffs_config.cpp
@@ -7,7 +7,7 @@ void spiffs_config_begin_and_reformat_if_necessary() {
   SPIFFS.begin(true);
 }
 
-String spiff_config_get(String name) {
+String spiffs_config_get(String name) {
   Serial.println("mounting FS...");
   spiffs_config_begin_and_reformat_if_necessary();
 
@@ -46,7 +46,7 @@ String spiff_config_get(String name) {
   return (String) NULL; // TODO something better than returning nulls
 }
 
-void spiff_config_set(String name, String value) {
+void spiffs_config_set(String name, String value) {
   Serial.println("Saving config");
   spiffs_config_begin_and_reformat_if_necessary();
 

--- a/src/spiffs_config.cpp
+++ b/src/spiffs_config.cpp
@@ -1,0 +1,72 @@
+
+#include <SPIFFS.h>
+#include <ArduinoJson.h> //https://github.com/bblanchon/ArduinoJson
+#include <WString.h>
+
+void spiffs_config_begin_and_reformat_if_necessary() {
+  SPIFFS.begin(true);
+}
+
+String spiff_config_get(String name) {
+  Serial.println("mounting FS...");
+  spiffs_config_begin_and_reformat_if_necessary();
+
+
+  Serial.println("mounted file system");
+  if (SPIFFS.exists("/config.json"))
+  {
+    // file exists, reading and loading
+    Serial.println("reading config file");
+    File configFile = SPIFFS.open("/config.json", "r");
+    if (configFile)
+    {
+      Serial.println("opened config file");
+      size_t size = configFile.size();
+      // Allocate a buffer to store contents of the file.
+      std::unique_ptr<char[]> buf(new char[size]);
+
+      configFile.readBytes(buf.get(), size);
+      DynamicJsonBuffer jsonBuffer;
+      JsonObject &json = jsonBuffer.parseObject(buf.get());
+      json.printTo(Serial);
+
+      if (json.success())
+      {
+        Serial.println("\nparsed json");
+
+        return json[name];
+      }
+      else
+      {
+        Serial.println("failed to load json config");
+      }
+    }
+  }
+
+  return (String) NULL; // TODO something better than returning nulls
+}
+
+void spiff_config_set(String name, String value) {
+  Serial.println("Saving config");
+  spiffs_config_begin_and_reformat_if_necessary();
+
+  DynamicJsonBuffer jsonBuffer;
+  JsonObject &json = jsonBuffer.createObject();
+  
+  // TODO this will overwrite all file contents with just one value.  need to support read->modify->write instead
+  json[name] = value;
+
+  File configFile = SPIFFS.open("/config.json", "w");
+
+  if (!configFile)
+  {
+    Serial.println("Failed to open config file for writing");
+  }
+  else
+  {
+    Serial.print("JSON config file: ");
+    json.printTo(Serial);
+    json.printTo(configFile);
+    configFile.close();
+  }
+}

--- a/src/spiffs_config.h
+++ b/src/spiffs_config.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <WString.h>
+#include <string>
+
+String spiff_config_get(String name);
+void spiff_config_set(String name, String value);

--- a/src/spiffs_config.h
+++ b/src/spiffs_config.h
@@ -3,5 +3,5 @@
 #include <WString.h>
 #include <string>
 
-String spiff_config_get(String name);
-void spiff_config_set(String name, String value);
+String spiffs_config_get(String name);
+void spiffs_config_set(String name, String value);

--- a/src/web_interface.cpp
+++ b/src/web_interface.cpp
@@ -14,54 +14,65 @@ MDNS mdns(udp);
 #define TEXT_BUFFER_SIZE 1024
 
 AsyncWebServer server(80);
-char text_buffer[TEXT_BUFFER_SIZE+1];
-int next_writable_index=0;
+char text_buffer[TEXT_BUFFER_SIZE + 1];
+int next_writable_index = 0;
 
 /* Must call this on main loop */
-void web_interface_loop() {
+void web_interface_loop()
+{
   mdns.run();
 }
 
-void web_interface_append(const String& text) {
+void web_interface_append(const String &text)
+{
   /* Do not copy null termination character from text */
   uint16_t num_chars_without_null_terminator = text.length();
 
   /* Insure new text doesn't overflow text buffer */
-  if (num_chars_without_null_terminator > TEXT_BUFFER_SIZE) {
+  if (num_chars_without_null_terminator > TEXT_BUFFER_SIZE)
+  {
     num_chars_without_null_terminator = TEXT_BUFFER_SIZE;
   }
 
   /* Move current buffer contents back to make enough space for new content */
-  for (int i=TEXT_BUFFER_SIZE; i>=num_chars_without_null_terminator; i--) {
-    text_buffer[i] = text_buffer[i-num_chars_without_null_terminator-1];
+  for (int i = TEXT_BUFFER_SIZE; i >= num_chars_without_null_terminator; i--)
+  {
+    text_buffer[i] = text_buffer[i - num_chars_without_null_terminator - 1];
   }
-  
+
   /* Separate new content with a newline */
   text_buffer[num_chars_without_null_terminator] = '\n';
 
   /* Copy new content in space previously created */
-  for (int i=0; i<num_chars_without_null_terminator; i++) {
+  for (int i = 0; i < num_chars_without_null_terminator; i++)
+  {
     text_buffer[i] = text.charAt(i);
   }
+
+  Serial.print("Text buffer: ");
+  Serial.println(text_buffer);
 }
 
-void notFound(AsyncWebServerRequest *request) {
-    request->send(404, "text/plain", "Not found");
+void notFound(AsyncWebServerRequest *request)
+{
+  request->send(404, "text/plain", "Not found");
 }
 
-void web_interface_setup() {
+void web_interface_setup()
+{
   /* Respond to MDNS queries for artnet.local */
   mdns.begin(WiFi.localIP(), "artnet");
 
   /* Insure null termination of string */
   text_buffer[TEXT_BUFFER_SIZE] = '\0';
 
-  server.on("/", HTTP_GET, [](AsyncWebServerRequest *request){
-      request->send(200, "text/plain", text_buffer);
-  });
+  server.on("/", HTTP_GET, [](AsyncWebServerRequest *request)
+            {   Serial.print("Text buffer: |");
+  Serial.print(text_buffer);
+  Serial.println("|");
+request->send(200, "text/plain", text_buffer); });
 
   server.onNotFound(notFound);
 
   server.begin();
 }
-

--- a/src/web_interface.h
+++ b/src/web_interface.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <ESPAsyncWebServer.h>
+
+extern AsyncWebServer server;
+
 void web_interface_setup();
 void web_interface_append(const String&);
 void web_interface_loop();

--- a/src/wifi_manager.cpp
+++ b/src/wifi_manager.cpp
@@ -9,6 +9,8 @@
 DNSServer wifi_manager_dns;
 char wifi_manager_universe[2];
 
+AsyncWiFiManager wifi_manager(&server, &wifi_manager_dns);
+
 // flag for saving data
 bool shouldSaveConfig = false;
 
@@ -17,6 +19,18 @@ void saveConfigCallback()
 {
   Serial.println("Should save config");
   shouldSaveConfig = true;
+}
+
+void wifi_manager_web_reset(AsyncWebServerRequest *request) {
+  Serial.println("Resetting wifi manager settings");
+  wifi_manager.resetSettings();
+  Serial.println("Wifi manager settings reset");
+  request->send(200, "text/plain", "Wifi manager settings reset");
+}
+
+void register_reset_page_with_web_server() {
+  Serial.println("Registering wifi manager reset at URL /reset");
+  server.on("/reset", HTTP_ANY, wifi_manager_web_reset);
 }
 
 void wifi_manager_setup()
@@ -67,13 +81,10 @@ void wifi_manager_setup()
   }
   // end read
 
-  AsyncWiFiManager wifi_manager(&server, &wifi_manager_dns);
+
   AsyncWiFiManagerParameter wifi_manager_param_universe("universe", "Art-Net to DMX Universe", wifi_manager_universe, 2);
   wifi_manager.setSaveConfigCallback(saveConfigCallback);
   wifi_manager.addParameter(&wifi_manager_param_universe);
-
-  // reset settings - for testing
-  //wifi_manager.resetSettings();
 
   // fetches ssid and pass and tries to connect
   // if it does not connect it starts an access point with the specified name
@@ -127,4 +138,6 @@ void wifi_manager_setup()
       SPIFFS.format();
     }
   }
+
+  register_reset_page_with_web_server();
 }

--- a/src/wifi_manager.cpp
+++ b/src/wifi_manager.cpp
@@ -1,13 +1,119 @@
-
+#include <SPIFFS.h> //this needs to be first, or it all crashes and burns...
 #include <WiFi.h>
 #include <ESPAsyncWebServer.h>
 #include <ESPAsyncWiFiManager.h>
+#include <ArduinoJson.h> //https://github.com/bblanchon/ArduinoJson
 
 AsyncWebServer wifi_manager_server(80);
 DNSServer wifi_manager_dns;
+char wifi_manager_universe[2];
 
-void wifi_manager_setup() {
-  AsyncWiFiManager wifi_manager(&wifi_manager_server,&wifi_manager_dns);
-  wifi_manager.autoConnect("ArtNet Wifi");
+// flag for saving data
+bool shouldSaveConfig = false;
+
+// callback notifying us of the need to save config
+void saveConfigCallback()
+{
+  Serial.println("Should save config");
+  shouldSaveConfig = true;
 }
 
+void wifi_manager_setup()
+{
+  // clean FS, for testing
+  // SPIFFS.format();
+
+  // read configuration from FS json
+  Serial.println("mounting FS...");
+
+  if (SPIFFS.begin())
+  {
+    Serial.println("mounted file system");
+    if (SPIFFS.exists("/config.json"))
+    {
+      // file exists, reading and loading
+      Serial.println("reading config file");
+      File configFile = SPIFFS.open("/config.json", "r");
+      if (configFile)
+      {
+        Serial.println("opened config file");
+        size_t size = configFile.size();
+        // Allocate a buffer to store contents of the file.
+        std::unique_ptr<char[]> buf(new char[size]);
+
+        configFile.readBytes(buf.get(), size);
+        DynamicJsonBuffer jsonBuffer;
+        JsonObject &json = jsonBuffer.parseObject(buf.get());
+        json.printTo(Serial);
+
+        if (json.success())
+        {
+          Serial.println("\nparsed json");
+
+          strcpy(wifi_manager_universe, json["wifi_manager_universe"]);
+        }
+        else
+        {
+          Serial.println("failed to load json config");
+        }
+      }
+    }
+  }
+  else
+  {
+    Serial.println("failed to mount FS");
+  }
+  // end read
+
+  AsyncWiFiManager wifi_manager(&wifi_manager_server, &wifi_manager_dns);
+  AsyncWiFiManagerParameter wifi_manager_param_universe("universe", "Art-Net to DMX Universe", wifi_manager_universe, 2);
+  wifi_manager.setSaveConfigCallback(saveConfigCallback);
+  wifi_manager.addParameter(&wifi_manager_param_universe);
+
+  // reset settings - for testing
+  // wifi_manager.resetSettings();
+
+  // fetches ssid and pass and tries to connect
+  // if it does not connect it starts an access point with the specified name
+  // here  "AutoConnectAP"
+  // and goes into a blocking loop awaiting configuration
+  Serial.println("About to autoconnect...");
+
+  if (!wifi_manager.autoConnect("Art-Net WiFi"))
+  {
+    Serial.println("Failed after autoconnect and hit timeout");
+    delay(3000);
+    // reset and try again, or maybe put it to deep sleep
+    ESP.restart();
+    delay(5000);
+  }
+
+  Serial.print("Done with autoconnect...  Universe Selected: ");
+  Serial.println(wifi_manager_param_universe.getValue());
+
+  // save the custom parameters to FS
+  if (shouldSaveConfig)
+  {
+    Serial.println("Saving config");
+
+    DynamicJsonBuffer jsonBuffer;
+    JsonObject &json = jsonBuffer.createObject();
+
+    strcpy(wifi_manager_universe, wifi_manager_param_universe.getValue());
+
+    json["wifi_manager_universe"] = wifi_manager_universe;
+
+    File configFile = SPIFFS.open("/config.json", "w");
+
+    if (!configFile)
+    {
+      Serial.println("Failed to open config file for writing");
+    }
+    else
+    {
+      json.printTo(Serial);
+      json.printTo(configFile);
+      configFile.close();
+    }
+  }
+}

--- a/src/wifi_manager.cpp
+++ b/src/wifi_manager.cpp
@@ -26,7 +26,8 @@ void wifi_manager_web_reset(AsyncWebServerRequest *request) {
   Serial.println("Resetting wifi manager settings");
   wifi_manager.resetSettings();
   Serial.println("Wifi manager settings reset");
-  request->send(200, "text/plain", "Wifi manager settings reset");
+  request->send(200, "text/plain", "Wifi manager settings reset.  Will restart");
+  ESP.restart();
 }
 
 void register_reset_page_with_web_server() {
@@ -41,7 +42,7 @@ void spiffs_begin_reformatting_if_necessary() {
 void wifi_manager_setup()
 {
   // read configuration from FS json and store in wifi_manager_universe
-  spiff_config_get("wifi_manager_universe").toCharArray(wifi_manager_universe, 3);
+  spiffs_config_get("wifi_manager_universe").toCharArray(wifi_manager_universe, 3);
 
   AsyncWiFiManagerParameter wifi_manager_param_universe("universe", "Art-Net to DMX Universe", wifi_manager_universe, 2);
   wifi_manager.setSaveConfigCallback(saveConfigCallback);
@@ -68,7 +69,7 @@ void wifi_manager_setup()
   // save the custom parameters to FS
   if (shouldSaveConfig)
   {
-    spiff_config_set("wifi_manager_universe", wifi_manager_param_universe.getValue());
+    spiffs_config_set("wifi_manager_universe", wifi_manager_param_universe.getValue());
   }
 
   register_reset_page_with_web_server();

--- a/src/wifi_manager.cpp
+++ b/src/wifi_manager.cpp
@@ -8,7 +8,7 @@
 #include <spiffs_config.h>
 
 DNSServer wifi_manager_dns;
-char wifi_manager_universe[2];
+char wifi_manager_dmx_port1_artnet_universe[3];
 
 AsyncWiFiManager wifi_manager(&server, &wifi_manager_dns);
 
@@ -22,36 +22,43 @@ void saveConfigCallback()
   shouldSaveConfig = true;
 }
 
-void wifi_manager_web_reset(AsyncWebServerRequest *request) {
+void wifi_manager_web_reset(AsyncWebServerRequest *request)
+{
   Serial.println("Resetting wifi manager settings");
+  request->send(200, "text/plain", "Clearing WiFi config.  Search for \"Art-Net Wifi\" access point to perform first-time setup.  Will restart in 10 seconds.  CLOSE YOUR BROWSER NOW.");
+  // Delay required to ensure HTTP response has time to get back to browser before we cut the WiFi connection.
+  // 1 second is too short.  10 seconds works but might be overkill.
+  delay(10000);
   wifi_manager.resetSettings();
   Serial.println("Wifi manager settings reset");
-  request->send(200, "text/plain", "Wifi manager settings reset.  Will restart");
+  // Delay required to ensure WiFi settings are reset before rebooting the device.
+  // 10 seconds works but might be overkill.
+  delay(10000);
   ESP.restart();
 }
 
-void register_reset_page_with_web_server() {
+void register_reset_page_with_web_server()
+{
   Serial.println("Registering wifi manager reset at URL /reset");
   server.on("/reset", HTTP_ANY, wifi_manager_web_reset);
 }
 
-void spiffs_begin_reformatting_if_necessary() {
+void spiffs_begin_reformatting_if_necessary()
+{
   !SPIFFS.begin(true);
 }
 
 void wifi_manager_setup()
 {
   // read configuration from FS json and store in wifi_manager_universe
-  spiffs_config_get("wifi_manager_universe").toCharArray(wifi_manager_universe, 3);
+  spiffs_config_get("wifi_manager_dmx_port1_artnet_universe").toCharArray(wifi_manager_dmx_port1_artnet_universe, 3);
 
-  AsyncWiFiManagerParameter wifi_manager_param_universe("universe", "Art-Net to DMX Universe", wifi_manager_universe, 2);
+  AsyncWiFiManagerParameter wifi_manager_param_dmx_port1_artnet_universe("universe", "DMX Port 1 Art-Net Universe", wifi_manager_dmx_port1_artnet_universe, 2);
   wifi_manager.setSaveConfigCallback(saveConfigCallback);
-  wifi_manager.addParameter(&wifi_manager_param_universe);
+  wifi_manager.addParameter(&wifi_manager_param_dmx_port1_artnet_universe);
 
-  // fetches ssid and pass and tries to connect
+  // fetches ssid and password and tries to connect
   // if it does not connect it starts an access point with the specified name
-  // here  "AutoConnectAP"
-  // and goes into a blocking loop awaiting configuration
   Serial.println("About to autoconnect...");
 
   if (!wifi_manager.autoConnect("Art-Net WiFi"))
@@ -64,12 +71,12 @@ void wifi_manager_setup()
   }
 
   Serial.print("Done with autoconnect...  Universe Selected: ");
-  Serial.println(wifi_manager_param_universe.getValue());
+  Serial.println(wifi_manager_param_dmx_port1_artnet_universe.getValue());
 
   // save the custom parameters to FS
   if (shouldSaveConfig)
   {
-    spiffs_config_set("wifi_manager_universe", wifi_manager_param_universe.getValue());
+    spiffs_config_set("wifi_manager_dmx_port1_artnet_universe", wifi_manager_param_dmx_port1_artnet_universe.getValue());
   }
 
   register_reset_page_with_web_server();


### PR DESCRIPTION
Add ability to specify which Art-Net universe is output on DMX Port 1, via the WiFi configuration interface.
Also add ability to reset WiFi config to default (i.e: force first-time config via Access Point) without needing to shut down all previously-connected-to WiFi networks.