### PR TITLE
Bugfix/flickering lights

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,6 +10,8 @@
 // If false, we will act as a DMX receiver
 const bool ARTNET_NODE = true;
 const bool LED_STRIP_CONTROL = false;
+const int MIN_DMX_REFRESH_RATE = 10;                       // Hz
+const int MAX_UPDATE_PERIOD = 1000 / MIN_DMX_REFRESH_RATE; // milliseconds
 
 u_int8_t dmx_data[512];
 unsigned long lastUpdate = millis();
@@ -108,8 +110,11 @@ void loop()
 
   if (ARTNET_NODE)
   {
-    if (read_from_artnet(dmx_data))
+    if (read_from_artnet(dmx_data) || (millis() - lastUpdate > MAX_UPDATE_PERIOD))
+    {
       write_to_dmx(dmx_data);
+      lastUpdate = millis();
+    }
   }
   else
   {


### PR DESCRIPTION
We were experiencing lights flickering on and off (and moving in the case of moving heads).  It looked like they were trying to reset every one second, as if they had lost DMX connection.  1Hz appears to be the rate at which MagicQ sends Art-Net data when no values have changed.  It appears that DMX requires a faster refresh rate than this.

This fix increases the refresh rate (regardless of whether data has changed or not) to 10Hz.  Docs suggest DMX can run at up to 44Hz, so this is within limits.  At 10Hz, lights appear to no longer flicker or move.  In fact, the moving heads appeared to work at 2Hz and the washes appear to work at 5Hz.  So 10Hz should give us some safety margin.  In any case, refresh rate has been parameterised with a constant for easy change in future.